### PR TITLE
Mac App Status Tracking for Today's Cart Items

### DIFF
--- a/Marshroom/Marshroom/App/AppDelegate.swift
+++ b/Marshroom/Marshroom/App/AppDelegate.swift
@@ -16,6 +16,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        appState?.stopFileWatcher()
         appState?.stopPolling()
     }
 
@@ -32,6 +33,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task {
             await appState.restoreCurrentUser()
             appState.startPolling()
+            appState.startFileWatcher()
         }
     }
 
@@ -41,6 +43,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task {
             await appState.restoreCurrentUser()
             appState.startPolling()
+            appState.startFileWatcher()
         }
     }
 }

--- a/Marshroom/Marshroom/Features/Mall/CartView.swift
+++ b/Marshroom/Marshroom/Features/Mall/CartView.swift
@@ -23,9 +23,23 @@ struct CartView: View {
                 Text("Today's Cart")
                     .font(.headline)
                 Spacer()
-                Text("\(appState.todayCart.count) items")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    ForEach(IssueStatus.allCases, id: \.self) { status in
+                        let count = appState.todayCart.filter { $0.status == status }.count
+                        if count > 0 {
+                            HStack(spacing: 3) {
+                                Image(systemName: status.iconName)
+                                    .font(.caption2)
+                                Text("\(count)")
+                                    .font(.caption)
+                            }
+                            .foregroundStyle(status.color)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(status.color.opacity(0.12), in: Capsule())
+                        }
+                    }
+                }
             }
             .padding()
 

--- a/Marshroom/Marshroom/Features/Pilot/MenuBarView.swift
+++ b/Marshroom/Marshroom/Features/Pilot/MenuBarView.swift
@@ -23,6 +23,30 @@ struct MenuBarView: View {
 
             Divider()
 
+            // Status summary bar
+            if !appState.todayCart.isEmpty {
+                HStack(spacing: 10) {
+                    ForEach([IssueStatus.running, .pending, .soon], id: \.self) { status in
+                        let count = appState.todayCart.filter { $0.status == status }.count
+                        if count > 0 {
+                            HStack(spacing: 3) {
+                                Circle()
+                                    .fill(status.color)
+                                    .frame(width: 8, height: 8)
+                                Text("\(count)")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+
+                Divider()
+            }
+
             if appState.todayCart.isEmpty {
                 // Empty state
                 VStack(spacing: 8) {
@@ -78,6 +102,11 @@ private struct MenuBarIssueRow: View {
 
     var body: some View {
         HStack(spacing: 8) {
+            Image(systemName: item.status.iconName)
+                .font(.caption)
+                .foregroundStyle(item.status.color)
+                .frame(width: 16)
+
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 4) {
                     Text("#\(item.issue.number)")
@@ -93,6 +122,10 @@ private struct MenuBarIssueRow: View {
             }
 
             Spacer()
+
+            Text(item.status.displayName)
+                .font(.caption2)
+                .foregroundStyle(item.status.color)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)


### PR DESCRIPTION
## Summary
- Add status indicators (icon + text) to each MenuBar issue row and a colored summary bar at the top
- Replace plain "N items" count in CartView header with per-status colored capsule badges
- Add `DispatchSource` file watcher on `~/.config/marshroom/` directory so the Mac app detects external `state.json` changes from CLI (`marsh start`, `marsh pr`) in real-time (~1s)
- Wire file watcher lifecycle in AppDelegate alongside existing GitHub poller

## Original Issue
The status is changed correctly in status.json, however, the feature tracks the status of 'today's cart' lacks. There are no way to check the status in Mac app. Think about efficient way to acheive this. Use plan mode + create a team of UI/UX designer, PM, and ios developer.

## Test Plan
- [x] Build succeeds: `xcodebuild -project Marshroom/Marshroom.xcodeproj -scheme Marshroom -configuration Debug build`
- [ ] MenuBar popup shows status icon + text per row, summary bar with colored dots at top
- [ ] CartView header shows capsule badges instead of plain item count
- [ ] Run `marsh start #N` from terminal — verify Mac app updates status within ~1 second
- [ ] Run `marsh pr` — verify pending status reflects in both views

close #2