### PR TITLE
Check IDE feature functionality and fix errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ xcodebuild -project Marshroom/Marshroom.xcodeproj -scheme Marshroom -configurati
 - `marsh hud` — tmux status bar + pane border output; branch-aware three-tier resolution (branch match → single/sole runner → summary)
 - `marsh start [#N]` — set cart item status to "running"
 - `marsh status` — show cart items for current repo (marks current branch with `→`)
-- `marsh open-ide` — open PyCharm for current directory
+- `marsh open-ide [pycharm|vscode]` — open IDE for current directory (auto-detects if omitted)
 - `marsh pr` — set status to "pending", store PR number/URL
 - Reads/writes `~/.config/marshroom/state.json` atomically
 
@@ -68,7 +68,7 @@ xcodebuild -project Marshroom/Marshroom.xcodeproj -scheme Marshroom -configurati
 1. **Draft**: Type raw idea in Issue Composer → Cmd+Enter → LLM title → Create Issue
 2. **Inject**: `/start-issue #123` → branch created, context loaded, status → running
 3. **Execute**: Claude codes → tmux HUD shows `🍄 #123 [Running]`
-4. **Review**: `Prefix+P` in tmux → PyCharm opens → review code
+4. **Review**: `Prefix+C-p` (PyCharm) or `Prefix+C-v` (VSCode) in tmux → IDE opens → review code
 5. **Ship**: `/create-pr` → PR with `Closes #N` → merge → issue auto-closes
 
 ## Key Architecture Notes

--- a/cli/marsh
+++ b/cli/marsh
@@ -274,8 +274,7 @@ cmd_status() {
     "#\(.issueNumber) \(.issueTitle)\n    Status: \(.status // "soon") | Branch: \(.branchName // "—")\(.prURL // "" | if . != "" then "\n    PR: \(.)" else "" end)\n"'
 }
 
-cmd_open_ide() {
-  # Try PyCharm variants in order
+open_pycharm() {
   if open -a "PyCharm Professional" "$(pwd)" 2>/dev/null; then
     echo "🍄 Opened PyCharm Professional"
   elif open -a "PyCharm CE" "$(pwd)" 2>/dev/null; then
@@ -286,11 +285,55 @@ cmd_open_ide() {
     pycharm . &
     echo "🍄 Opened PyCharm (CLI launcher)"
   else
-    echo "Error: PyCharm not found." >&2
-    echo "Install PyCharm from: https://www.jetbrains.com/pycharm/download/" >&2
-    echo "Or install via brew: brew install --cask pycharm" >&2
-    exit 1
+    return 1
   fi
+}
+
+open_vscode() {
+  if open -a "Visual Studio Code" "$(pwd)" 2>/dev/null; then
+    echo "🍄 Opened Visual Studio Code"
+  elif open -a "Visual Studio Code - Insiders" "$(pwd)" 2>/dev/null; then
+    echo "🍄 Opened Visual Studio Code - Insiders"
+  elif command -v code &>/dev/null; then
+    code .
+    echo "🍄 Opened VSCode (CLI launcher)"
+  else
+    return 1
+  fi
+}
+
+cmd_open_ide() {
+  local ide="${1:-${MARSH_IDE:-}}"
+
+  case "$ide" in
+    pycharm)
+      open_pycharm || {
+        echo "Error: PyCharm not found." >&2
+        echo "Install via: brew install --cask pycharm" >&2
+        exit 1
+      }
+      ;;
+    vscode)
+      open_vscode || {
+        echo "Error: VSCode not found." >&2
+        echo "Install via: brew install --cask visual-studio-code" >&2
+        exit 1
+      }
+      ;;
+    "")
+      # Auto-detect: try PyCharm first (backward compat), then VSCode
+      open_pycharm 2>/dev/null || open_vscode 2>/dev/null || {
+        echo "Error: No supported IDE found (tried PyCharm, VSCode)." >&2
+        echo "Install one: brew install --cask pycharm" >&2
+        echo "         or: brew install --cask visual-studio-code" >&2
+        exit 1
+      }
+      ;;
+    *)
+      echo "Error: Unknown IDE '${ide}'. Supported: pycharm, vscode" >&2
+      exit 1
+      ;;
+  esac
 }
 
 cmd_pr() {
@@ -386,14 +429,17 @@ cmd_help() {
 Usage: marsh <command> [options]
 
 Commands:
-  hud          Output tmux-formatted status string for current repo
-  start [#N]   Mark a cart issue as running (prompts if multiple)
-  status       Show cart entries for the current repo
-  open-ide     Open current directory in PyCharm
-  pr           Mark current branch's issue as pending (PR created)
-  help         Show this help message
+  hud              Output tmux-formatted status string for current repo
+  start [#N]       Mark a cart issue as running (prompts if multiple)
+  status           Show cart entries for the current repo
+  open-ide [ide]   Open directory in IDE (pycharm, vscode; auto-detects if omitted)
+  pr               Mark current branch's issue as pending (PR created)
+  help             Show this help message
 
 State file: ~/.config/marshroom/state.json
+
+Environment variables:
+  MARSH_IDE        Default IDE when no argument given (pycharm, vscode)
 
 tmux integration (tpm):
   set -g @plugin 'vkehfdl1/Marshroom'
@@ -404,6 +450,9 @@ Examples:
   marsh start #42        # start working on issue #42
   marsh start            # interactive pick if multiple issues
   marsh status           # show all cart items for current repo
+  marsh open-ide         # auto-detect IDE and open
+  marsh open-ide vscode  # open in VSCode
+  marsh open-ide pycharm # open in PyCharm
   marsh pr               # mark current branch as PR pending
 HELP
 }
@@ -414,7 +463,7 @@ case "${1:-help}" in
   hud)      shift; cmd_hud "${1:-}" ;;
   start)    shift; cmd_start "${1:-}" ;;
   status)   cmd_status ;;
-  open-ide) cmd_open_ide ;;
+  open-ide) shift; cmd_open_ide "${1:-}" ;;
   pr)       cmd_pr ;;
   help|--help|-h) cmd_help ;;
   *)

--- a/marshroom.tmux
+++ b/marshroom.tmux
@@ -10,7 +10,8 @@ source "$CURRENT_DIR/cli/scripts/helpers.sh"
 
 marshroom_status_interval=$(get_tmux_option "@marshroom_interval" "5")
 marshroom_status_right_length=$(get_tmux_option "@marshroom_status_right_length" "80")
-marshroom_open_ide_key=$(get_tmux_option "@marshroom_open_ide_key" "P")
+marshroom_open_pycharm_key=$(get_tmux_option "@marshroom_open_pycharm_key" "C-p")
+marshroom_open_vscode_key=$(get_tmux_option "@marshroom_open_vscode_key" "C-v")
 marshroom_status_key=$(get_tmux_option "@marshroom_status_key" "I")
 marshroom_pane_format=$(get_tmux_option "@marshroom_pane_format" " #{marshroom_status} | #P: #{b:pane_current_path} ")
 
@@ -59,5 +60,6 @@ set_tmux_option "status-right-length" "$marshroom_status_right_length"
 
 MARSH="$CURRENT_DIR/cli/marsh"
 
-tmux bind-key "$marshroom_open_ide_key" run-shell -b "cd '#{pane_current_path}' && '$MARSH' open-ide"
+tmux bind-key "$marshroom_open_pycharm_key" run-shell -b "cd '#{pane_current_path}' && '$MARSH' open-ide pycharm"
+tmux bind-key "$marshroom_open_vscode_key" run-shell -b "cd '#{pane_current_path}' && '$MARSH' open-ide vscode"
 tmux bind-key "$marshroom_status_key" display-popup -d '#{pane_current_path}' -E "'$MARSH' status"


### PR DESCRIPTION
## Summary

- Refactored `marsh open-ide` to support both PyCharm and VSCode with explicit selection, `MARSH_IDE` env var fallback, and auto-detection
- Replaced the single tmux keybinding (`Prefix+P`) with two: `Prefix+C-p` (PyCharm) and `Prefix+C-v` (VSCode), resolving the conflict with tmux's built-in "previous window"
- Updated all documentation (CLAUDE.md, user-guide.md) to reflect the new IDE integration

## Original Issue

Check IDE feature is working and fix some errors

close #6