### PR TITLE
Remove unnecessary green icon indicator from issue panel

### DIFF
--- a/Marshroom/Marshroom/Features/Mall/IssueRowView.swift
+++ b/Marshroom/Marshroom/Features/Mall/IssueRowView.swift
@@ -11,10 +11,6 @@ struct IssueRowView: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            Image(systemName: "circle.fill")
-                .foregroundStyle(.green)
-                .padding(.top, 2)
-
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
                     Text("#\(issue.number)")


### PR DESCRIPTION
## Summary
Remove the static green `circle.fill` icon that appeared next to every issue number in the Issue Mall panel. The indicator served no functional purpose — it wasn't tied to issue state (open/closed) or any other data — and cluttered the UI.

## Original Issue
> The green icon at the issue panel (which is located next to every issue number) looks unnecessary. Why is this existed?

## Changes
- Removed `Image(systemName: "circle.fill")` with `.foregroundStyle(.green)` from `IssueRowView.swift`

close #10