### PR TITLE
Auto-assign added cart item to current user

### DIFF
--- a/Marshroom/Marshroom/Core/AppStateManager.swift
+++ b/Marshroom/Marshroom/Core/AppStateManager.swift
@@ -138,6 +138,16 @@ final class AppStateManager {
 
         todayCart.append(item)
         syncStateFile()
+
+        if let apiClient, let login = currentUser?.login {
+            Task {
+                try? await apiClient.assignIssue(
+                    repo: repo.fullName,
+                    number: issue.number,
+                    assignees: [login]
+                )
+            }
+        }
     }
 
     func removeIssueFromCart(_ item: CartItem) {

--- a/Marshroom/Marshroom/Services/GitHubAPIClient.swift
+++ b/Marshroom/Marshroom/Services/GitHubAPIClient.swift
@@ -52,6 +52,20 @@ actor GitHubAPIClient {
         return try await request(endpoint: "/repos/\(repo)/issues", method: "POST", body: payload)
     }
 
+    // MARK: - Issue Assignment
+
+    @discardableResult
+    func assignIssue(repo: String, number: Int, assignees: [String]) async throws -> GitHubIssue {
+        struct AssignIssueBody: Encodable {
+            let assignees: [String]
+        }
+        return try await request(
+            endpoint: "/repos/\(repo)/issues/\(number)/assignees",
+            method: "POST",
+            body: AssignIssueBody(assignees: assignees)
+        )
+    }
+
     // MARK: - File Content
 
     func fetchFileContent(repo: String, path: String) async throws -> String {


### PR DESCRIPTION
## Summary
- Add `assignIssue()` method to `GitHubAPIClient` using the GitHub Assignees API (`POST /repos/{owner}/{repo}/issues/{number}/assignees`)
- Call it fire-and-forget from `addIssueToCart()` in `AppStateManager` after syncing state, so the authenticated user is auto-assigned on GitHub when adding an issue to the cart

## Original Issue
After adding the issue to today's cart, auto-assign the issue to me. (Just write the issue, don't need to read the assignee and double-check that the assign is complete)

close #19