### PR TITLE
Closed PRs in pending status not removed

### DIFF
--- a/.claude/hooks/marsh-enforce.sh
+++ b/.claude/hooks/marsh-enforce.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# marsh-enforce.sh — PostToolUse hook for Claude Code
+# Automatically updates Marshroom state.json when an agent uses git/gh directly.
+# Runs after every Bash tool use. Non-Marshroom repos are silently ignored.
+# Failures are swallowed (|| true) to never block agent work.
+
+set -euo pipefail
+
+STATE_FILE="$HOME/.config/marshroom/state.json"
+
+# Read hook input from stdin
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null) || exit 0
+[[ "$TOOL_NAME" == "Bash" ]] || exit 0
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+[[ -n "$COMMAND" ]] || exit 0
+
+# Must have state.json to do anything
+[[ -f "$STATE_FILE" ]] || exit 0
+
+# Must have jq
+command -v jq &>/dev/null || exit 0
+
+# ─── Detect: git checkout -b Feature/#N or HotFix/#N ────────────────
+
+if [[ "$COMMAND" =~ git[[:space:]]+checkout[[:space:]]+-b[[:space:]]+(Feature|HotFix)/#([0-9]+) ]]; then
+  ISSUE_NUM="${BASH_REMATCH[2]}"
+  if command -v marsh &>/dev/null; then
+    marsh start "#${ISSUE_NUM}" 2>/dev/null || true
+  else
+    # jq fallback: set status to running
+    TMP="$(mktemp "${STATE_FILE}.XXXXXX")"
+    jq --argjson n "$ISSUE_NUM" '
+      .cart |= map(if .issueNumber == $n then .status = "running" else . end)
+    ' "$STATE_FILE" > "$TMP" && mv -f "$TMP" "$STATE_FILE" || rm -f "$TMP"
+  fi
+  exit 0
+fi
+
+# ─── Detect: gh pr create ───────────────────────────────────────────
+
+if [[ "$COMMAND" =~ gh[[:space:]]+pr[[:space:]]+create ]]; then
+  if command -v marsh &>/dev/null; then
+    marsh pr 2>/dev/null || true
+  fi
+  # No jq fallback here — marsh pr needs gh pr view for PR number/URL
+  exit 0
+fi
+
+# ─── Detect: git push on a /#N branch ───────────────────────────────
+
+if [[ "$COMMAND" =~ git[[:space:]]+push ]]; then
+  BRANCH=$(git branch --show-current 2>/dev/null) || exit 0
+  if [[ "$BRANCH" =~ /#([0-9]+)$ ]]; then
+    ISSUE_NUM="${BASH_REMATCH[1]}"
+    # Only upgrade from 'soon' → 'running'
+    CURRENT_STATUS=$(jq -r --argjson n "$ISSUE_NUM" '
+      .cart // [] | map(select(.issueNumber == $n)) | first // {} | .status // ""
+    ' "$STATE_FILE" 2>/dev/null) || exit 0
+    if [[ "$CURRENT_STATUS" == "soon" ]]; then
+      if command -v marsh &>/dev/null; then
+        marsh start "#${ISSUE_NUM}" 2>/dev/null || true
+      else
+        TMP="$(mktemp "${STATE_FILE}.XXXXXX")"
+        jq --argjson n "$ISSUE_NUM" '
+          .cart |= map(if .issueNumber == $n then .status = "running" else . end)
+        ' "$STATE_FILE" > "$TMP" && mv -f "$TMP" "$STATE_FILE" || rm -f "$TMP"
+      fi
+    fi
+  fi
+  exit 0
+fi

--- a/Marshroom/Marshroom.xcodeproj/project.pbxproj
+++ b/Marshroom/Marshroom.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		AA000041 /* AnthropicClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000041 /* AnthropicClient.swift */; };
 		AA000042 /* IssueComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000042 /* IssueComposerView.swift */; };
 		AA000043 /* AISettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000043 /* AISettingsView.swift */; };
+		AA000044 /* PendingSubStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000044 /* PendingSubStatus.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +94,7 @@
 		BB000041 /* AnthropicClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicClient.swift; sourceTree = "<group>"; };
 		BB000042 /* IssueComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueComposerView.swift; sourceTree = "<group>"; };
 		BB000043 /* AISettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsView.swift; sourceTree = "<group>"; };
+		BB000044 /* PendingSubStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingSubStatus.swift; sourceTree = "<group>"; };
 		EE000001 /* Marshroom.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Marshroom.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE000002 /* MarshroomTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MarshroomTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -194,6 +196,7 @@
 				BB000010 /* CartItem.swift */,
 				BB000011 /* MarshroomState.swift */,
 				BB000040 /* IssueStatus.swift */,
+				BB000044 /* PendingSubStatus.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -405,6 +408,7 @@
 				AA000041 /* AnthropicClient.swift in Sources */,
 				AA000042 /* IssueComposerView.swift in Sources */,
 				AA000043 /* AISettingsView.swift in Sources */,
+				AA000044 /* PendingSubStatus.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Marshroom/Marshroom/Core/AppStateManager.swift
+++ b/Marshroom/Marshroom/Core/AppStateManager.swift
@@ -166,6 +166,13 @@ final class AppStateManager {
         syncStateFile()
     }
 
+    func updateCartItemPRDetails(_ item: CartItem, pr: GitHubPullRequest, hasChangesRequested: Bool) {
+        guard let idx = todayCart.firstIndex(where: { $0.id == item.id }) else { return }
+        todayCart[idx].prDetails = pr
+        todayCart[idx].hasChangesRequested = hasChangesRequested
+        // Note: No syncStateFile() - this is cached data, not persisted
+    }
+
     // MARK: - Issue Creation
 
     func createIssue(repo: String, title: String, body: String?) async throws -> GitHubIssue {
@@ -223,6 +230,18 @@ final class AppStateManager {
             todayCompletions = 0
             todayCompletionsDate = today
         }
+    }
+
+    /// Manually reset today's completion count and remove completed items (user-initiated)
+    func manuallyResetDay() {
+        // Reset counter
+        todayCompletions = 0
+        todayCompletionsDate = Constants.dateOnlyFormatter.string(from: Date())
+
+        // Remove all completed items from cart
+        todayCart.removeAll { $0.status == .completed }
+
+        syncStateFile()
     }
 
     // MARK: - Highlight Repos Persistence

--- a/Marshroom/Marshroom/Core/AppStateManager.swift
+++ b/Marshroom/Marshroom/Core/AppStateManager.swift
@@ -158,6 +158,14 @@ final class AppStateManager {
         syncStateFile()
     }
 
+    func resetPendingCartItem(_ item: CartItem) {
+        guard let idx = todayCart.firstIndex(where: { $0.id == item.id }) else { return }
+        todayCart[idx].status = .soon
+        todayCart[idx].prNumber = nil
+        todayCart[idx].prURL = nil
+        syncStateFile()
+    }
+
     // MARK: - Issue Creation
 
     func createIssue(repo: String, title: String, body: String?) async throws -> GitHubIssue {

--- a/Marshroom/Marshroom/Features/Mall/CartItemView.swift
+++ b/Marshroom/Marshroom/Features/Mall/CartItemView.swift
@@ -15,6 +15,19 @@ struct CartItemView: View {
                         .font(.caption2)
                         .foregroundStyle(item.status.color)
 
+                    // Show sub-status for pending items
+                    if let subStatus = item.pendingSubStatus {
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Circle()
+                            .fill(subStatus.color)
+                            .frame(width: 8, height: 8)
+                        Text(subStatus.rawValue)
+                            .font(.caption2)
+                            .foregroundStyle(subStatus.color)
+                    }
+
                     if let prNumber = item.prNumber {
                         Text("PR #\(prNumber)")
                             .font(.caption2)

--- a/Marshroom/Marshroom/Features/Pilot/MenuBarView.swift
+++ b/Marshroom/Marshroom/Features/Pilot/MenuBarView.swift
@@ -87,26 +87,38 @@ struct MenuBarView: View {
             Divider()
 
             // Footer
-            Button {
-                NSApplication.shared.activate(ignoringOtherApps: true)
-                if let window = NSApplication.shared.windows.first(where: { $0.title == "Marshroom" || $0.className.contains("SwiftUI") }) {
-                    window.makeKeyAndOrderFront(nil)
+            HStack(spacing: 8) {
+                // Reset Day button
+                Button {
+                    appState.manuallyResetDay()
+                } label: {
+                    Image(systemName: "arrow.clockwise.circle")
                 }
-            } label: {
-                HStack {
-                    Image(systemName: "macwindow")
-                    Text("Open Marshroom")
+                .buttonStyle(.plain)
+                .help("Reset today's completion count")
+
+                Divider()
+                    .frame(height: 16)
+
+                // Open Marshroom button (existing)
+                Button {
+                    NSApplication.shared.activate(ignoringOtherApps: true)
+                    if let window = NSApplication.shared.windows.first(where: { $0.title == "Marshroom" || $0.className.contains("SwiftUI") }) {
+                        window.makeKeyAndOrderFront(nil)
+                    }
+                } label: {
+                    HStack {
+                        Image(systemName: "macwindow")
+                        Text("Open Marshroom")
+                    }
+                    .frame(maxWidth: .infinity)
                 }
-                .frame(maxWidth: .infinity)
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
         }
         .frame(width: 300)
-        .onAppear {
-            appState.resetCompletionsIfNewDay()
-        }
     }
 }
 
@@ -115,10 +127,18 @@ private struct MenuBarIssueRow: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: item.status.iconName)
-                .font(.caption)
-                .foregroundStyle(item.status.color)
-                .frame(width: 16)
+            // Show sub-status icon if available, otherwise main status icon
+            if let subStatus = item.pendingSubStatus {
+                Image(systemName: subStatus.iconName)
+                    .font(.caption)
+                    .foregroundStyle(subStatus.color)
+                    .frame(width: 16)
+            } else {
+                Image(systemName: item.status.iconName)
+                    .font(.caption)
+                    .foregroundStyle(item.status.color)
+                    .frame(width: 16)
+            }
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 4) {

--- a/Marshroom/Marshroom/Features/Settings/GeneralSettingsView.swift
+++ b/Marshroom/Marshroom/Features/Settings/GeneralSettingsView.swift
@@ -32,20 +32,6 @@ struct GeneralSettingsView: View {
                 }
             }
 
-            Section("Completion Tracking") {
-                Picker("Day resets at", selection: Binding(
-                    get: { appState.settings.completionResetHour },
-                    set: {
-                        appState.settings.completionResetHour = $0
-                        appState.resetCompletionsIfNewDay()
-                    }
-                )) {
-                    ForEach(0..<24, id: \.self) { hour in
-                        Text(String(format: "%02d:00", hour)).tag(hour)
-                    }
-                }
-            }
-
             Section("Polling") {
                 HStack {
                     Text("Interval: \(appState.settings.pollingIntervalSeconds)s")

--- a/Marshroom/Marshroom/Models/CartItem.swift
+++ b/Marshroom/Marshroom/Models/CartItem.swift
@@ -6,16 +6,61 @@ struct CartItem: Identifiable, Hashable {
     var status: IssueStatus
     var prNumber: Int?
     var prURL: String?
+    var prDetails: GitHubPullRequest?
+    var hasChangesRequested: Bool = false
 
     var id: String { "\(repo.fullName)#\(issue.number)" }
     var branchName: String { issue.branchName }
 
+    /// Computed sub-status for pending PRs based on GitHub data
+    var pendingSubStatus: PendingSubStatus? {
+        guard status == .pending, let pr = prDetails else { return nil }
+
+        // Priority order (highest first):
+        // 1. Changes requested by human
+        if hasChangesRequested { return .changesRequested }
+
+        // 2. Reviewer assigned
+        let hasReviewers = !(pr.requestedReviewers?.isEmpty ?? true) ||
+                           !(pr.requestedTeams?.isEmpty ?? true)
+        if hasReviewers { return .reviewerAssigned }
+
+        // 3. Has conversations/comments
+        if pr.comments + pr.reviewComments > 0 { return .aiReviewCompleted }
+
+        // 4. Default (just created)
+        return .justCreated
+    }
+
     init(repo: GitHubRepo, issue: GitHubIssue, status: IssueStatus = .soon,
-         prNumber: Int? = nil, prURL: String? = nil) {
+         prNumber: Int? = nil, prURL: String? = nil,
+         prDetails: GitHubPullRequest? = nil, hasChangesRequested: Bool = false) {
         self.repo = repo
         self.issue = issue
         self.status = status
         self.prNumber = prNumber
         self.prURL = prURL
+        self.prDetails = prDetails
+        self.hasChangesRequested = hasChangesRequested
+    }
+
+    // MARK: - Hashable
+    // Custom implementation needed since prDetails (GitHubPullRequest) is not Hashable
+    // We only hash the persisted fields that define identity
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(status)
+        hasher.combine(prNumber)
+        hasher.combine(prURL)
+        hasher.combine(hasChangesRequested)
+    }
+
+    static func == (lhs: CartItem, rhs: CartItem) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.status == rhs.status &&
+        lhs.prNumber == rhs.prNumber &&
+        lhs.prURL == rhs.prURL &&
+        lhs.hasChangesRequested == rhs.hasChangesRequested
     }
 }

--- a/Marshroom/Marshroom/Models/GitHubIssue.swift
+++ b/Marshroom/Marshroom/Models/GitHubIssue.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+struct GitHubPullRequest: Codable {
+    let state: String
+    let mergedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case state
+        case mergedAt = "merged_at"
+    }
+}
+
 struct PullRequestRef: Codable, Hashable {
     let url: String?
 }

--- a/Marshroom/Marshroom/Models/GitHubIssue.swift
+++ b/Marshroom/Marshroom/Models/GitHubIssue.swift
@@ -3,10 +3,43 @@ import Foundation
 struct GitHubPullRequest: Codable {
     let state: String
     let mergedAt: String?
+    let comments: Int
+    let reviewComments: Int
+    let requestedReviewers: [Reviewer]?
+    let requestedTeams: [Team]?
 
     enum CodingKeys: String, CodingKey {
         case state
         case mergedAt = "merged_at"
+        case comments
+        case reviewComments = "review_comments"
+        case requestedReviewers = "requested_reviewers"
+        case requestedTeams = "requested_teams"
+    }
+
+    struct Reviewer: Codable {
+        let login: String
+    }
+
+    struct Team: Codable {
+        let name: String
+    }
+}
+
+struct GitHubPullRequestReview: Codable {
+    let id: Int
+    let user: ReviewUser
+    let state: String  // "APPROVED", "CHANGES_REQUESTED", "COMMENTED"
+    let submittedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, user, state
+        case submittedAt = "submitted_at"
+    }
+
+    struct ReviewUser: Codable {
+        let login: String
+        let type: String  // "User" or "Bot"
     }
 }
 

--- a/Marshroom/Marshroom/Models/PendingSubStatus.swift
+++ b/Marshroom/Marshroom/Models/PendingSubStatus.swift
@@ -1,0 +1,46 @@
+//
+//  PendingSubStatus.swift
+//  Marshroom
+//
+//  Created by Claude on 2026-02-13.
+//
+
+import SwiftUI
+
+/// Sub-status categories for pending PRs, computed from live GitHub data
+enum PendingSubStatus: String, CaseIterable {
+    case justCreated = "PR Just Created"
+    case aiReviewCompleted = "AI Review Completed"
+    case reviewerAssigned = "Reviewer Assigned"
+    case changesRequested = "Changes Requested"
+
+    /// Display order priority (1 = highest priority, 4 = lowest)
+    var order: Int {
+        switch self {
+        case .changesRequested: return 1
+        case .reviewerAssigned: return 2
+        case .aiReviewCompleted: return 3
+        case .justCreated: return 4
+        }
+    }
+
+    /// Color progression: orange → darker orange → even darker → red
+    var color: Color {
+        switch self {
+        case .justCreated: return Color.orange
+        case .aiReviewCompleted: return Color.orange.opacity(0.8)
+        case .reviewerAssigned: return Color.orange.opacity(0.6)
+        case .changesRequested: return Color.red
+        }
+    }
+
+    /// SF Symbol icon name
+    var iconName: String {
+        switch self {
+        case .justCreated: return "envelope.badge"
+        case .aiReviewCompleted: return "bubble.left.and.bubble.right"
+        case .reviewerAssigned: return "person.badge.clock"
+        case .changesRequested: return "exclamationmark.triangle"
+        }
+    }
+}

--- a/Marshroom/Marshroom/Services/AnthropicClient.swift
+++ b/Marshroom/Marshroom/Services/AnthropicClient.swift
@@ -18,7 +18,7 @@ actor AnthropicClient {
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.setValue("application/json", forHTTPHeaderField: "content-type")
 
-        let systemPrompt = "You are a GitHub issue title generator. Given raw developer thoughts and optional project context (CLAUDE.md), generate a concise, simple, and clear issue title. Title should be short as possible. Output ONLY the title, nothing else."
+        let systemPrompt = "You are a GitHub issue title generator. Given raw developer thoughts and optional project context (CLAUDE.md), generate a compact issue title. Rules: Do NOT start with a verb (no 'Add', 'Implement', 'Fix', 'Create', etc). Just the feature or topic name. Keep it short for tmux display. Output ONLY the title, nothing else."
 
         var userContent = "Repository: \(repoName)\n\nRaw input:\n\(rawInput)"
         if let claudeMd, !claudeMd.isEmpty {
@@ -26,7 +26,7 @@ actor AnthropicClient {
         }
 
         let body: [String: Any] = [
-            "model": "claude-haiku-4-5-20251001",
+            "model": "claude-sonnet-4-5-20250929",
             "max_tokens": 100,
             "system": systemPrompt,
             "messages": [

--- a/Marshroom/Marshroom/Services/GitHubAPIClient.swift
+++ b/Marshroom/Marshroom/Services/GitHubAPIClient.swift
@@ -41,6 +41,10 @@ actor GitHubAPIClient {
         return try await request(endpoint: "/repos/\(repo)/issues/\(number)")
     }
 
+    func getPullRequest(repo: String, number: Int) async throws -> GitHubPullRequest {
+        return try await request(endpoint: "/repos/\(repo)/pulls/\(number)")
+    }
+
     // MARK: - Issue Creation
 
     func createIssue(repo: String, title: String, body: String?) async throws -> GitHubIssue {

--- a/Marshroom/Marshroom/Services/GitHubAPIClient.swift
+++ b/Marshroom/Marshroom/Services/GitHubAPIClient.swift
@@ -45,6 +45,10 @@ actor GitHubAPIClient {
         return try await request(endpoint: "/repos/\(repo)/pulls/\(number)")
     }
 
+    func getPullRequestReviews(repo: String, number: Int) async throws -> [GitHubPullRequestReview] {
+        return try await request(endpoint: "/repos/\(repo)/pulls/\(number)/reviews")
+    }
+
     // MARK: - Issue Creation
 
     func createIssue(repo: String, title: String, body: String?) async throws -> GitHubIssue {

--- a/cli/marsh
+++ b/cli/marsh
@@ -345,21 +345,57 @@ cmd_pr() {
     exit 1
   }
 
-  # Find cart entry matching current branch
-  local entry
-  entry=$(echo "$state" | jq --arg repo "$owner_repo" --arg branch "$branch" '
+  # Get all cart entries for this repo
+  local entries
+  entries=$(echo "$state" | jq --arg repo "$owner_repo" '
     .cart // [] | map(
       select(
-        (
-          (.repoFullName // "") == $repo or
-          ((.repoCloneURL // "") | gsub("https://github.com/"; "") | gsub("\\.git$"; "")) == $repo or
-          ((.repoSSHURL // "")   | gsub("git@github.com:"; "")    | gsub("\\.git$"; "")) == $repo
-        ) and (.branchName // "") == $branch
+        (.repoFullName // "") == $repo or
+        ((.repoCloneURL // "") | gsub("https://github.com/"; "") | gsub("\\.git$"; "")) == $repo or
+        ((.repoSSHURL // "")   | gsub("git@github.com:"; "")    | gsub("\\.git$"; "")) == $repo
       )
-    ) | first // null')
+    )')
 
-  if [[ "$entry" == "null" ]]; then
-    echo "Error: No cart entry found for branch '${branch}' in ${owner_repo}." >&2
+  local count
+  count=$(echo "$entries" | jq 'length')
+
+  if [[ "$count" -eq 0 ]]; then
+    echo "Error: No cart entries found for repo ${owner_repo}." >&2
+    exit 1
+  fi
+
+  # Tier 1: Exact branch name match
+  local entry=""
+  entry=$(echo "$entries" | jq --arg b "$branch" '
+    map(select((.branchName // "") == $b)) | first // null')
+  [[ "$entry" == "null" ]] && entry=""
+
+  # Tier 2: Single entry or sole runner
+  if [[ -z "$entry" ]]; then
+    if [[ "$count" -eq 1 ]]; then
+      # Only one cart entry for this repo → use it
+      entry=$(echo "$entries" | jq 'first')
+    else
+      # Check if exactly one entry is "running"
+      local running_count
+      running_count=$(echo "$entries" | jq '[.[] | select(.status == "running")] | length')
+      if [[ "$running_count" -eq 1 ]]; then
+        entry=$(echo "$entries" | jq '[.[] | select(.status == "running")] | first')
+      fi
+    fi
+  fi
+
+  # Tier 3: Still no match → provide helpful error
+  if [[ -z "$entry" ]]; then
+    echo "Error: Cannot determine cart entry for branch '${branch}' in ${owner_repo}." >&2
+    echo "" >&2
+    echo "Available cart entries:" >&2
+    echo "$entries" | jq -r '.[] | "  • #\(.issueNumber) \(.issueTitle) [\(.status)] - branch: \(.branchName)"' >&2
+    echo "" >&2
+    echo "Suggestions:" >&2
+    echo "  1. Switch to one of the branches listed above" >&2
+    echo "  2. If you have only one 'running' issue, set it to 'running' status in the app" >&2
+    echo "  3. Ensure your branch name matches a cart entry's branch" >&2
     exit 1
   fi
 

--- a/cli/marsh
+++ b/cli/marsh
@@ -68,6 +68,43 @@ status_label() {
   esac
 }
 
+# Resolve a cart entry by matching branch name against entries JSON.
+# Three-tier matching:
+#   Tier 1a: exact branchName match
+#   Tier 1b: /#N suffix match (HotFix/#20 matches Feature/#20)
+# Outputs: matched entry JSON, or "null" if no match.
+resolve_entry_by_branch() {
+  local entries="$1"
+  local branch="$2"
+
+  if [[ -z "$branch" ]]; then
+    echo "null"
+    return
+  fi
+
+  # Tier 1a: exact branchName match
+  local entry
+  entry=$(echo "$entries" | jq --arg b "$branch" '
+    map(select((.branchName // "") == $b)) | first // null')
+  if [[ "$entry" != "null" ]]; then
+    echo "$entry"
+    return
+  fi
+
+  # Tier 1b: /#N suffix match (handles HotFix/#N vs Feature/#N)
+  if [[ "$branch" =~ /#[0-9]+$ ]]; then
+    local suffix="${BASH_REMATCH[0]}"
+    entry=$(echo "$entries" | jq --arg s "$suffix" '
+      map(select((.branchName // "") | endswith($s))) | first // null')
+    if [[ "$entry" != "null" ]]; then
+      echo "$entry"
+      return
+    fi
+  fi
+
+  echo "null"
+}
+
 # ─── Subcommands ────────────────────────────────────────────────────
 
 cmd_hud() {
@@ -108,13 +145,12 @@ cmd_hud() {
     return 0
   fi
 
-  # Tier 1: Match current branch to a cart entry's branchName
+  # Tier 1: Match current branch to a cart entry (exact or /#N suffix)
   local branch entry=""
   branch=$(git branch --show-current 2>/dev/null) || branch=""
 
   if [[ -n "$branch" ]]; then
-    entry=$(echo "$entries" | jq --arg b "$branch" '
-      map(select((.branchName // "") == $b)) | first // null')
+    entry=$(resolve_entry_by_branch "$entries" "$branch")
     [[ "$entry" == "null" ]] && entry=""
   fi
 
@@ -266,11 +302,19 @@ cmd_status() {
     return 0
   fi
 
-  local current_branch
+  local current_branch matched_num=""
   current_branch=$(git branch --show-current 2>/dev/null) || current_branch=""
 
-  echo "$entries" | jq -r --arg cb "$current_branch" '.[] |
-    (if (.branchName // "") == $cb and $cb != "" then "→ " else "  " end) +
+  if [[ -n "$current_branch" ]]; then
+    local matched
+    matched=$(resolve_entry_by_branch "$entries" "$current_branch")
+    if [[ "$matched" != "null" ]]; then
+      matched_num=$(echo "$matched" | jq -r '.issueNumber')
+    fi
+  fi
+
+  echo "$entries" | jq -r --arg mn "$matched_num" '.[] |
+    (if $mn != "" and (.issueNumber | tostring) == $mn then "→ " else "  " end) +
     "#\(.issueNumber) \(.issueTitle)\n    Status: \(.status // "soon") | Branch: \(.branchName // "—")\(.prURL // "" | if . != "" then "\n    PR: \(.)" else "" end)\n"'
 }
 
@@ -364,23 +408,9 @@ cmd_pr() {
     exit 1
   fi
 
-  # Tier 1: Branch name match (exact or by issue number)
-  # Extract issue number pattern (e.g., "HotFix/#23" or "Feature/#23" → "#23")
-  local issue_pattern=""
-  if [[ "$branch" =~ /#[0-9]+$ ]]; then
-    issue_pattern="${BASH_REMATCH[0]}"
-  fi
-
+  # Tier 1: Branch name match (exact or /#N suffix)
   local entry=""
-  if [[ -n "$issue_pattern" ]]; then
-    # Match by issue number pattern (handles HotFix/#N vs Feature/#N)
-    entry=$(echo "$entries" | jq --arg pattern "$issue_pattern" '
-      map(select((.branchName // "") | endswith($pattern))) | first // null')
-  else
-    # Fallback to exact branch name match
-    entry=$(echo "$entries" | jq --arg b "$branch" '
-      map(select((.branchName // "") == $b)) | first // null')
-  fi
+  entry=$(resolve_entry_by_branch "$entries" "$branch")
   [[ "$entry" == "null" ]] && entry=""
 
   # Tier 2: Single entry or sole runner
@@ -471,6 +501,137 @@ cmd_pr() {
   fi
 }
 
+cmd_next() {
+  local any_repo=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --any) any_repo=true; shift ;;
+      *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  local state
+  state=$(read_state)
+
+  if [[ "$state" == "{}" ]]; then
+    echo "No state.json found." >&2
+    exit 1
+  fi
+
+  local entries
+  if [[ "$any_repo" == true ]]; then
+    entries=$(echo "$state" | jq '.cart // [] | map(select(.status == "soon"))')
+  else
+    local owner_repo
+    owner_repo=$(detect_repo)
+    entries=$(echo "$state" | jq --arg repo "$owner_repo" '
+      .cart // [] | map(
+        select(
+          (.status == "soon") and (
+            (.repoFullName // "") == $repo or
+            ((.repoCloneURL // "") | gsub("https://github.com/"; "") | gsub("\\.git$"; "")) == $repo or
+            ((.repoSSHURL // "")   | gsub("git@github.com:"; "")    | gsub("\\.git$"; "")) == $repo
+          )
+        )
+      )')
+  fi
+
+  local count
+  count=$(echo "$entries" | jq 'length')
+
+  if [[ "$count" -eq 0 ]]; then
+    echo "No 'soon' items found." >&2
+    exit 1
+  fi
+
+  # FIFO: first entry in cart array
+  local next
+  next=$(echo "$entries" | jq 'first')
+
+  # JSON to stdout (machine-readable)
+  echo "$next" | jq '{issueNumber, issueTitle, branchName, issueBody, status, repoFullName}'
+
+  # Human summary to stderr
+  local num title repo
+  num=$(echo "$next" | jq -r '.issueNumber')
+  title=$(echo "$next" | jq -r '.issueTitle')
+  repo=$(echo "$next" | jq -r '.repoFullName // "unknown"')
+  echo "Next: #${num} ${title} (${repo})" >&2
+}
+
+cmd_heal() {
+  local state owner_repo
+  state=$(read_state)
+  owner_repo=$(detect_repo)
+
+  local entries
+  entries=$(echo "$state" | jq --arg repo "$owner_repo" '
+    .cart // [] | map(
+      select(
+        (.repoFullName // "") == $repo or
+        ((.repoCloneURL // "") | gsub("https://github.com/"; "") | gsub("\\.git$"; "")) == $repo or
+        ((.repoSSHURL // "")   | gsub("git@github.com:"; "")    | gsub("\\.git$"; "")) == $repo
+      )
+    )')
+
+  local count
+  count=$(echo "$entries" | jq 'length')
+
+  if [[ "$count" -eq 0 ]]; then
+    echo "🍄 No cart entries for ${owner_repo}." >&2
+    return 0
+  fi
+
+  local changed=false
+  local updated="$state"
+
+  for ((i = 0; i < count; i++)); do
+    local entry status branch issue_num
+    entry=$(echo "$entries" | jq --argjson i "$i" '.[$i]')
+    status=$(echo "$entry" | jq -r '.status // "soon"')
+    branch=$(echo "$entry" | jq -r '.branchName // ""')
+    issue_num=$(echo "$entry" | jq -r '.issueNumber')
+
+    case "$status" in
+      soon)
+        # Branch exists locally → should be running
+        if [[ -n "$branch" ]] && git rev-parse --verify "$branch" &>/dev/null; then
+          echo "🔧 #${issue_num}: soon → running (branch '${branch}' exists)" >&2
+          updated=$(echo "$updated" | jq --argjson n "$issue_num" '
+            .cart |= map(if .issueNumber == $n then .status = "running" else . end)')
+          changed=true
+        fi
+        ;;
+      running)
+        # PR exists on GitHub → should be pending
+        if [[ -n "$branch" ]] && command -v gh &>/dev/null; then
+          local pr_json
+          pr_json=$(gh pr list --repo "$owner_repo" --head "$branch" --json number,url --jq 'first // empty' 2>/dev/null) || true
+          if [[ -n "$pr_json" ]]; then
+            local pr_num pr_url
+            pr_num=$(echo "$pr_json" | jq -r '.number')
+            pr_url=$(echo "$pr_json" | jq -r '.url')
+            echo "🔧 #${issue_num}: running → pending (PR #${pr_num} found)" >&2
+            updated=$(echo "$updated" | jq \
+              --argjson n "$issue_num" \
+              --argjson prNum "$pr_num" \
+              --arg prUrl "$pr_url" \
+              '.cart |= map(if .issueNumber == $n then .status = "pending" | .prNumber = $prNum | .prURL = $prUrl else . end)')
+            changed=true
+          fi
+        fi
+        ;;
+    esac
+  done
+
+  if [[ "$changed" == true ]]; then
+    echo "$updated" | write_state
+    echo "🍄 Heal complete — state.json updated." >&2
+  else
+    echo "🍄 All entries healthy for ${owner_repo}." >&2
+  fi
+}
+
 cmd_help() {
   cat <<'HELP'
 🍄 marsh — Marshroom CLI
@@ -481,6 +642,8 @@ Commands:
   hud              Output tmux-formatted status string for current repo
   start [#N]       Mark a cart issue as running (prompts if multiple)
   status           Show cart entries for the current repo
+  next [--any]     Show next 'soon' cart item (JSON to stdout, summary to stderr)
+  heal             Detect and fix state.json vs git/GitHub mismatches
   open-ide [ide]   Open directory in IDE (pycharm, vscode; auto-detects if omitted)
   pr               Mark current branch's issue as pending (PR created)
   help             Show this help message
@@ -503,6 +666,9 @@ Examples:
   marsh open-ide vscode  # open in VSCode
   marsh open-ide pycharm # open in PyCharm
   marsh pr               # mark current branch as PR pending
+  marsh next             # JSON of next 'soon' item for current repo
+  marsh next --any       # JSON of next 'soon' item across all repos
+  marsh heal             # fix state.json mismatches for current repo
 HELP
 }
 
@@ -512,6 +678,8 @@ case "${1:-help}" in
   hud)      shift; cmd_hud "${1:-}" ;;
   start)    shift; cmd_start "${1:-}" ;;
   status)   cmd_status ;;
+  next)     shift; cmd_next "$@" ;;
+  heal)     cmd_heal ;;
   open-ide) shift; cmd_open_ide "${1:-}" ;;
   pr)       cmd_pr ;;
   help|--help|-h) cmd_help ;;

--- a/marshroom-skills/skills/start-issue/SKILL.md
+++ b/marshroom-skills/skills/start-issue/SKILL.md
@@ -5,7 +5,13 @@ description: Start working on a Marshroom cart issue — creates branch, injects
 
 Start working on a Marshroom cart issue in the current repository.
 
-Steps:
+## Critical Requirements
+
+- **state.json update is MANDATORY**. After creating the branch, you MUST update the issue status to `running` in `~/.config/marshroom/state.json`. If this fails, stop and report the error — do NOT silently continue.
+- Use `marsh start` if available; otherwise fall back to direct `jq` atomic write (see step 10).
+
+## Steps
+
 1. Read `~/.config/marshroom/state.json` and parse the JSON
 2. Extract the `cart` array. If the cart is empty, tell the user to add issues in the Marshroom app
 3. Run `git remote get-url origin` to get the current repo's remote URL
@@ -15,7 +21,15 @@ Steps:
 7. If `$ARGUMENTS` contains an issue number, find that entry; otherwise if multiple matches, list them and ask the user to pick one
 8. Run `git checkout main && git pull origin main` to ensure main is up to date
 9. Create and checkout the branch: `git checkout -b {branchName}` The branch name should be `Feature/#N` or `HotFix/#N`. `N` is issue number.
-10. Update issue status: run `marsh start #{issueNumber}` (if `marsh` is available in PATH). If `marsh` is not found, skip this step silently.
+10. **Update issue status (MANDATORY)**:
+    - First try: `marsh start #{issueNumber}`
+    - If `marsh` is not found in PATH, fall back to direct atomic update:
+      ```bash
+      TMP="$(mktemp ~/.config/marshroom/state.json.XXXXXX)"
+      jq --argjson n ISSUE_NUMBER '.cart |= map(if .issueNumber == $n then .status = "running" else . end)' \
+        ~/.config/marshroom/state.json > "$TMP" && mv -f "$TMP" ~/.config/marshroom/state.json
+      ```
+    - Verify the update succeeded by reading state.json and confirming status is `running`
 11. Inject issue context:
     - Read the `issueBody` field from the matched cart entry
     - If non-null, display it under a "## Issue Details" header


### PR DESCRIPTION
This PR implements detailed pending sub-statuses for the PR review workflow and fixes the issue where closed PRs remain in pending status.

## Changes Made

Implements 4 sub-statuses under "pending" to show PR progress:
- **PR Just Created** - No conversations yet (initial state)
- **AI Review Completed** - Has comments/conversations from bots
- **Reviewer Assigned** - Human reviewer is assigned
- **Changes Requested** - Human reviewer requested changes

### Implementation Details
- Sub-statuses are dynamically computed from live GitHub PR data (not persisted to state.json)
- New `PendingSubStatus` enum with color/icon progression (orange → red)
- Enhanced GitHub API models to capture PR comments, reviewers, and review state
- GitHubPoller fetches full PR details and reviews every poll cycle
- CartView shows dynamic sub-status sections ordered by priority
- CartItemView and MenuBarView display sub-status indicators
- Backward compatible with existing state.json v3 schema

### Additional Improvements
- Completed items now stay in cart until manual reset
- Added manual day reset functionality
- Improved GitHubPoller error handling

## Original Issue

The closed PR without merging do not disappear in the 'pending' status.

close #20