### PR TITLE
title gen prompt engineering

### DIFF
--- a/Marshroom/Marshroom/Services/AnthropicClient.swift
+++ b/Marshroom/Marshroom/Services/AnthropicClient.swift
@@ -18,7 +18,7 @@ actor AnthropicClient {
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.setValue("application/json", forHTTPHeaderField: "content-type")
 
-        let systemPrompt = "You are a GitHub issue title generator. Given raw developer thoughts and optional project context (CLAUDE.md), generate a concise, simple, and clear issue title. Title should be short as possible. Output ONLY the title, nothing else."
+        let systemPrompt = "You are a GitHub issue title generator. Given raw developer thoughts and optional project context (CLAUDE.md), generate a compact issue title. Rules: Do NOT start with a verb (no 'Add', 'Implement', 'Fix', 'Create', etc). Just the feature or topic name. Keep it short for tmux display. Output ONLY the title, nothing else."
 
         var userContent = "Repository: \(repoName)\n\nRaw input:\n\(rawInput)"
         if let claudeMd, !claudeMd.isEmpty {
@@ -26,7 +26,7 @@ actor AnthropicClient {
         }
 
         let body: [String: Any] = [
-            "model": "claude-haiku-4-5-20251001",
+            "model": "claude-sonnet-4-5-20250929",
             "max_tokens": 100,
             "system": systemPrompt,
             "messages": [


### PR DESCRIPTION
## Summary
- Update title generation system prompt to prohibit leading verbs (Add, Implement, Fix, Create, etc) — outputs compact topic-only titles suitable for tmux display
- Upgrade title generation model from Claude Haiku (`claude-haiku-4-5-20251001`) to Claude Sonnet 4.5 (`claude-sonnet-4-5-20250929`) for better quality
- `testConnection()` remains on Haiku since it's just a connectivity check

## Original Issue
When generating issue, I don't need the verb like 'add' 'implement' and so on. Only need a feature name. without verb. Compact as possible, good to see in tmux. Plus upgrade model to sonnet 4.5 for better quality. haiku is too dumb

close #17

🍄 Generated with [Claude Code](https://claude.com/claude-code)