### PR TITLE
Support MARSHROOM_STATE env var for multi-machine state.json sharing

### DIFF
--- a/.claude/hooks/marsh-enforce.sh
+++ b/.claude/hooks/marsh-enforce.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-STATE_FILE="$HOME/.config/marshroom/state.json"
+STATE_FILE="${MARSHROOM_STATE:-$HOME/.config/marshroom/state.json}"
 
 # Read hook input from stdin
 INPUT=$(cat)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ docs/                   — Architecture & user documentation
 - async/await concurrency throughout
 - Keychain: GitHub PAT + Anthropic API key (separate entries)
 - UserDefaults: settings via `SettingsStorage`
-- `~/.config/marshroom/state.json`: bridge between macOS app, CLI, and Claude Code skills
+- `~/.config/marshroom/state.json`: bridge between macOS app, CLI, and Claude Code skills (overridable via `MARSHROOM_STATE` env var)
 
 ## Build
 ```bash
@@ -44,7 +44,7 @@ xcodebuild -project Marshroom/Marshroom.xcodeproj -scheme Marshroom -configurati
 - `marsh status` — show cart items for current repo (marks current branch with `→`)
 - `marsh open-ide [pycharm|vscode]` — open IDE for current directory (auto-detects if omitted)
 - `marsh pr` — set status to "pending", store PR number/URL
-- Reads/writes `~/.config/marshroom/state.json` atomically
+- Reads/writes `${MARSHROOM_STATE:-~/.config/marshroom/state.json}` atomically
 
 ### 3. Claude Code Skills (.claude/commands/)
 - `/start-issue` — read state.json, create branch, inject CLAUDE.md + issue body context, call `marsh start`
@@ -59,6 +59,7 @@ xcodebuild -project Marshroom/Marshroom.xcodeproj -scheme Marshroom -configurati
 - **Repo matching**: skills + CLI detect repo via `git remote get-url origin`, match against state.json URLs
 - **Smart Ingestion**: raw idea → Claude Haiku generates optimized title → GitHub issue created
 - **CLAUDE.md cache**: fetched via GitHub Contents API, cached in state.json RepoEntry, TTL 1 hour
+- **Multi-machine**: `MARSHROOM_STATE` env var overrides state.json path; NFS mount + Tailscale enables shared state across machines. App uses poll-based watching for remote paths (kqueue can't detect NFS changes)
 
 ## Status Pipeline
 | Status | Meaning | Set By |

--- a/Marshroom/Marshroom/Core/Constants.swift
+++ b/Marshroom/Marshroom/Core/Constants.swift
@@ -5,11 +5,35 @@ enum Constants {
     static let minPollingIntervalSeconds = 10
     static let maxPollingIntervalSeconds = 120
     static let rateLimitWarningThreshold = 100
-    static let stateFileDirectory: String = {
+
+    /// Resolved state file path. Priority: MARSHROOM_STATE env var → UserDefaults → default.
+    static var stateFilePath: String {
+        if let envPath = ProcessInfo.processInfo.environment["MARSHROOM_STATE"], !envPath.isEmpty {
+            return envPath
+        }
+        if let customPath = UserDefaults.standard.string(forKey: "customStateFilePath"), !customPath.isEmpty {
+            return customPath
+        }
         let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return "\(home)/.config/marshroom"
+        return "\(home)/.config/marshroom/state.json"
+    }
+
+    /// Directory containing the state file.
+    static var stateFileDirectory: String {
+        (stateFilePath as NSString).deletingLastPathComponent
+    }
+
+    /// True when the state file is outside `$HOME` (e.g. NFS mount). kqueue won't detect remote changes.
+    static var stateFileIsRemote: Bool {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return !stateFilePath.hasPrefix(home)
+    }
+
+    static let defaultStateFilePath: String = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.config/marshroom/state.json"
     }()
-    static let stateFilePath = stateFileDirectory + "/state.json"
+
     static let gitHubAPIBaseURL = "https://api.github.com"
     static let anthropicAPIBaseURL = "https://api.anthropic.com"
     static let claudeMdCacheTTLSeconds = 3600

--- a/Marshroom/Marshroom/Core/SettingsStorage.swift
+++ b/Marshroom/Marshroom/Core/SettingsStorage.swift
@@ -22,6 +22,10 @@ final class SettingsStorage {
         didSet { UserDefaults.standard.set(completionResetHour, forKey: Keys.completionResetHour) }
     }
 
+    var customStateFilePath: String? {
+        didSet { UserDefaults.standard.set(customStateFilePath, forKey: Keys.customStateFilePath) }
+    }
+
     init() {
         let defaults = UserDefaults.standard
         let interval = defaults.integer(forKey: Keys.pollingInterval)
@@ -31,6 +35,7 @@ final class SettingsStorage {
         self.selectedRepoFullName = defaults.string(forKey: Keys.selectedRepo)
         let resetHour = defaults.object(forKey: Keys.completionResetHour) as? Int
         self.completionResetHour = resetHour ?? 0
+        self.customStateFilePath = defaults.string(forKey: Keys.customStateFilePath)
     }
 
     // MARK: - Highlight Repos Persistence
@@ -56,5 +61,6 @@ final class SettingsStorage {
         static let selectedRepo = "selectedRepoFullName"
         static let highlightReposData = "highlightReposData"
         static let completionResetHour = "completionResetHour"
+        static let customStateFilePath = "customStateFilePath"
     }
 }

--- a/Marshroom/Marshroom/Features/Settings/SettingsWindow.swift
+++ b/Marshroom/Marshroom/Features/Settings/SettingsWindow.swift
@@ -12,6 +12,6 @@ struct SettingsWindow: View {
             AISettingsView()
                 .tabItem { Label("AI", systemImage: "sparkles") }
         }
-        .frame(width: 450, height: 350)
+        .frame(width: 450, height: 420)
     }
 }

--- a/cli/marsh
+++ b/cli/marsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-STATE_FILE="$HOME/.config/marshroom/state.json"
+STATE_FILE="${MARSHROOM_STATE:-$HOME/.config/marshroom/state.json}"
 
 # ─── Dependency check ───────────────────────────────────────────────
 
@@ -648,9 +648,10 @@ Commands:
   pr               Mark current branch's issue as pending (PR created)
   help             Show this help message
 
-State file: ~/.config/marshroom/state.json
+State file: ${MARSHROOM_STATE:-~/.config/marshroom/state.json}
 
 Environment variables:
+  MARSHROOM_STATE  Override state.json path (for multi-machine setups)
   MARSH_IDE        Default IDE when no argument given (pycharm, vscode)
 
 tmux integration (tpm):

--- a/marshroom-skills/skills/create-pr/SKILL.md
+++ b/marshroom-skills/skills/create-pr/SKILL.md
@@ -7,12 +7,12 @@ Create a Pull Request for a Marshroom cart issue matching the current branch.
 
 ## Critical Requirements
 
-- **state.json update is MANDATORY**. After creating the PR, you MUST update the issue status to `pending` with `prNumber` and `prURL` in `~/.config/marshroom/state.json`. If this fails, stop and report the error — do NOT silently continue.
+- **state.json update is MANDATORY**. After creating the PR, you MUST update the issue status to `pending` with `prNumber` and `prURL` in `${MARSHROOM_STATE:-~/.config/marshroom/state.json}`. If this fails, stop and report the error — do NOT silently continue.
 - Use `marsh pr` if available; otherwise fall back to direct `jq` atomic write (see step 9).
 
 ## Steps
 
-1. Read `~/.config/marshroom/state.json` and parse the JSON
+1. Read `${MARSHROOM_STATE:-~/.config/marshroom/state.json}` and parse the JSON
 2. Run `git branch --show-current` to get the current branch name
 3. Find the cart entry matching the current branch and repo. Use relaxed matching:
    - First try exact `branchName` match
@@ -36,10 +36,11 @@ Create a Pull Request for a Marshroom cart issue matching the current branch.
    - First try: `marsh pr`
    - If `marsh` is not found in PATH, fall back to direct atomic update using the PR number and URL from step 8:
      ```bash
-     TMP="$(mktemp ~/.config/marshroom/state.json.XXXXXX)"
+     STATE_FILE="${MARSHROOM_STATE:-~/.config/marshroom/state.json}"
+     TMP="$(mktemp "${STATE_FILE}.XXXXXX")"
      jq --argjson n ISSUE_NUMBER --argjson prNum PR_NUMBER --arg prUrl "PR_URL" \
        '.cart |= map(if .issueNumber == $n then .status = "pending" | .prNumber = $prNum | .prURL = $prUrl else . end)' \
-       ~/.config/marshroom/state.json > "$TMP" && mv -f "$TMP" ~/.config/marshroom/state.json
+       "$STATE_FILE" > "$TMP" && mv -f "$TMP" "$STATE_FILE"
      ```
    - Verify the update succeeded by reading state.json and confirming status is `pending`
 10. Display the result:

--- a/marshroom-skills/skills/start-issue/SKILL.md
+++ b/marshroom-skills/skills/start-issue/SKILL.md
@@ -7,12 +7,12 @@ Start working on a Marshroom cart issue in the current repository.
 
 ## Critical Requirements
 
-- **state.json update is MANDATORY**. After creating the branch, you MUST update the issue status to `running` in `~/.config/marshroom/state.json`. If this fails, stop and report the error — do NOT silently continue.
+- **state.json update is MANDATORY**. After creating the branch, you MUST update the issue status to `running` in `${MARSHROOM_STATE:-~/.config/marshroom/state.json}`. If this fails, stop and report the error — do NOT silently continue.
 - Use `marsh start` if available; otherwise fall back to direct `jq` atomic write (see step 10).
 
 ## Steps
 
-1. Read `~/.config/marshroom/state.json` and parse the JSON
+1. Read `${MARSHROOM_STATE:-~/.config/marshroom/state.json}` and parse the JSON
 2. Extract the `cart` array. If the cart is empty, tell the user to add issues in the Marshroom app
 3. Run `git remote get-url origin` to get the current repo's remote URL
 4. Extract `owner/repo` from the remote URL (handle both HTTPS and SSH formats)
@@ -25,9 +25,10 @@ Start working on a Marshroom cart issue in the current repository.
     - First try: `marsh start #{issueNumber}`
     - If `marsh` is not found in PATH, fall back to direct atomic update:
       ```bash
-      TMP="$(mktemp ~/.config/marshroom/state.json.XXXXXX)"
+      STATE_FILE="${MARSHROOM_STATE:-~/.config/marshroom/state.json}"
+      TMP="$(mktemp "${STATE_FILE}.XXXXXX")"
       jq --argjson n ISSUE_NUMBER '.cart |= map(if .issueNumber == $n then .status = "running" else . end)' \
-        ~/.config/marshroom/state.json > "$TMP" && mv -f "$TMP" ~/.config/marshroom/state.json
+        "$STATE_FILE" > "$TMP" && mv -f "$TMP" "$STATE_FILE"
       ```
     - Verify the update succeeded by reading state.json and confirming status is `running`
 11. Inject issue context:

--- a/marshroom-skills/skills/validate-pr/SKILL.md
+++ b/marshroom-skills/skills/validate-pr/SKILL.md
@@ -6,7 +6,7 @@ description: Validate the current Pull Request branch name, body, and status aga
 Validate the current Pull Request against Marshroom conventions.
 
 Steps:
-1. Read `~/.config/marshroom/state.json` and parse the JSON
+1. Read `${MARSHROOM_STATE:-~/.config/marshroom/state.json}` and parse the JSON
 2. Run `git branch --show-current` to get the current branch name
 3. Find the cart entry whose `branchName` matches the current git branch. If no match, tell the user they're not on a cart issue branch
 4. Get the current PR info: `gh pr view --json title,body,headRefName`


### PR DESCRIPTION
## Summary
- Add `MARSHROOM_STATE` env var support across CLI, skills, hooks, and macOS app for overriding the state.json path
- Add Settings → General → State File UI with Browse/Reset and remote path detection
- Auto-switch to poll-based file watching (3s interval) for remote/NFS paths where kqueue can't detect changes
- Document multi-machine setup (NFS + Tailscale) in user guide

## Test plan
- [ ] Run without env var — default behavior unchanged
- [ ] `MARSHROOM_STATE=/tmp/test.json marsh status` — uses custom path
- [ ] Settings UI: change path → file watcher restarts
- [ ] NFS mount path → poll-based watching kicks in
- [ ] Build: `xcodebuild -project Marshroom/Marshroom.xcodeproj -scheme Marshroom -configuration Debug build CODE_SIGN_IDENTITY="-" CODE_SIGNING_ALLOWED=YES`

close #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)